### PR TITLE
Reuse plan file during apply if passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,9 @@ The plan is uploaded as a GitHub Workflow Run Artifact and named per input `plan
   - type: String
   - optional
   - default: `"./"`
+- `plan_path` - (optional) Path to a Terraform Plan file to reuse
+  - type: String
+  - optional
 - `backend_config` - (optional) Additional backend configuration to use during 'terraform init'. See https://developer.hashicorp.com/terraform/language/settings/backends/configuration#partial-configuration.
   - type: String
   - optional

--- a/apply/action.yaml
+++ b/apply/action.yaml
@@ -9,6 +9,9 @@ inputs:
     description: path to terraform configurations
     required: true
     default: "./"
+  plan_path:
+    description: path to a terraform plan file to reuse
+    required: false
   backend_config:
     description: Additional backend configuration to use during 'terraform init'. See https://developer.hashicorp.com/terraform/language/settings/backends/configuration#partial-configuration.
     required: false
@@ -41,4 +44,22 @@ runs:
       id: apply
       shell: bash
       working-directory: ${{ inputs.path }}
-      run: terraform apply -auto-approve -input=false -no-color 2>&1
+      env:
+        IS_VMX_PLAN_PATH_DEFINED: ${{ inputs.plan_path != '' }}
+        VMX_PLAN_PATH: ${{ inputs.plan_path }}
+      run: |
+        if [ "$IS_VMX_PLAN_PATH_DEFINED" == "true" ]; then
+          if [ -f "$VMX_PLAN_PATH" ]; then
+            echo -e "Running from cached Terraform Plan at $VMX_PLAN_PATH...\n"
+            echo -e "Showing cached plan...\n"
+            terraform show -no-color "$VMX_PLAN_PATH"
+
+            echo -e "Applying cached plan...\n"
+            terraform apply -auto-approve -input=false -no-color "$VMX_PLAN_PATH" 2>&1
+          else
+            echo "A path to a Terraform Plan equal to $VMX_PLAN_PATH was provided, but it does not represent a file!" 1>&2
+            exit 1
+          fi
+        else
+          terraform apply -auto-approve -input=false -no-color 2>&1
+        fi


### PR DESCRIPTION
If a path to an existing plan file is passed via input `plan_path`, then attempt to reuse it.