### PR TITLE
fix: DEVOPS-2381 | Escape backticks in plan validation

### DIFF
--- a/plan/action.yaml
+++ b/plan/action.yaml
@@ -96,6 +96,10 @@ runs:
 
     - uses: actions/github-script@v7
       if: ${{ github.event_name == 'pull_request' }}
+      env:
+        VALIDATE_STDOUT: ${{ steps.validate.outputs.stdout }}
+        VALIDATE_STDERR: ${{ steps.validate.outputs.stderr }}
+        PLAN_STDERR: ${{ steps.plan.outputs.stderr }}
       with:
         github-token: ${{ inputs.github_token }}
         script: |
@@ -129,10 +133,10 @@ runs:
 
           // Show errors if not validated successfully
           if (validateExitCode === '0') {
-            validateOutput = `${{ steps.validate.outputs.stdout }}`;
+            validateOutput = process.env.VALIDATE_STDOUT || '';
           }
           else {
-            validateOutput = `${{ steps.validate.outputs.stderr }}`;
+            validateOutput = process.env.VALIDATE_STDERR || '';
           }
 
           // Show errors if not planned successfully.
@@ -140,7 +144,7 @@ runs:
             rawPlanOutput = fs.readFileSync('plan.out', 'utf8')
           }
           else {
-            rawPlanOutput = `${{ steps.plan.outputs.stderr }}`;
+            rawPlanOutput = process.env.PLAN_STDERR || '';
           }
 
           // Show the last maxPlanChars characters of the plan output if too long


### PR DESCRIPTION
Closes https://app.clickup.com/t/10558396/DEVOPS-2381
Avoiding syntax conflicts with special characters by passing the TF output as variables.